### PR TITLE
Updating README.

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -7,24 +7,24 @@
 The most recent development is located in the [osquery fork by iBigQ](https://github.com/iBigQ/osquery).
 
 ```
-git clone --recursive https://github.com/iBigQ/osquery -b bro_integration_actor
+git clone --recursive https://github.com/iBigQ/osquery -b osquery-bro-actor
 cd osquery
 make deps
-make && sudo make install
+./tools/provision.sh install osquery/osquery-local/caf
+./tools/provision.sh install osquery/osquery-local/broker
+SKIP_BRO=False make && sudo make install
 ```
 
-Compared to osquery's upstream "bro-integration" branch, the version
-in this branch includes (1) updating to osquery version 2.11.2
-(submitted as [PR
-#4093](https://github.com/facebook/osquery/pull/4093); (2) switch to
-the new Broker API; and (3) switch to CAF 0.15.5.
+Compared to osquery's upstream `bro-integration` branch, the version
+in this branch includes switch to the new Broker API
+and switch to CAF 0.15.5.
 
 ## 2. Bro
 
 ### CAF Dependency
 
 ```
-git clone --recursive https://github.com/actor-framework/actor-framework 0.15.5
+git clone --recursive https://github.com/actor-framework/actor-framework -b 0.15.5
 cd actor-framework
 ./configure && make && sudo make install
 ```

--- a/install/README.md
+++ b/install/README.md
@@ -4,103 +4,45 @@
 
 ### Code Base
 
-The base to start with is located in the osquery repository in the [`bro-integration`](https://github.com/facebook/osquery/tree/bro-integration) branch. 
-This code is based on an old osquery version and extended with the full broker functionalities to communicate with Bro.
-
-Since we have no direct control over the osquery repository, we will continue to build the latest version. 
-More recent development is located in the [osquery fork by iBigQ](https://github.com/iBigQ/osquery).
+The most recent development is located in the [osquery fork by iBigQ](https://github.com/iBigQ/osquery).
 
 ```
-git clone https://github.com/iBigQ/osquery
+git clone --recursive https://github.com/iBigQ/osquery -b bro_integration_actor
 cd osquery
-git checkout bro-integration
-git submodule update --init
-git checkout -b bro-integration-local
-```
-
-### Update osquery
-
-At this point, we have the exact version as in the `bro-integration` branch of the osquery repository. 
-However, the osquery version in place is too old to be compiled. Therefore, we have to update to the latest osquery version (2.11.2).
-This is already submitted upstream [PR #4093](https://github.com/facebook/osquery/pull/4093).
-
-```
-git merge origin/bro-integration-2.11.2
-git submodule update --init
-```
-
-### Update broker (optional)
-
-At this point, we have a working source of the lastest osquery with the support for bro integration.
-As the next optional step, we can update broker. As in the `bro-integration` branch, the broker version 0.6 and caf version 0.14.6 is used.
-
-To update broker, we refer to the broker branch `topic/actor-system` and caf branch `develop`. 
-This is already submitted upstream [PR #3732](https://github.com/facebook/osquery/pull/3732).
-
-```
-git merge origin/bro_integration_actor
-```
-
-### Build osquery
-
-```
 make deps
 make && sudo make install
 ```
 
+Compared to osquery's upstream "bro-integration" branch, the version
+in this branch includes (1) updating to osquery version 2.11.2
+(submitted as [PR
+#4093](https://github.com/facebook/osquery/pull/4093); (2) switch to
+the new Broker API; and (3) switch to CAF 0.15.5.
 
 ## 2. Bro
 
 ### CAF Dependency
 
 ```
-git clone --recursive https://github.com/actor-framework/actor-framework
+git clone --recursive https://github.com/actor-framework/actor-framework 0.15.5
 cd actor-framework
-git checkout 0.14.6
-git submodule update --init
-```
-
-Optionally, when using the new Broker version, use the latest development version of caf.
-
-```
-git checkout develop
-git submodule update --init
-```
-
-Now, build caf.
-
-```
-./configure --no-examples --no-qt-examples --no-protobuf-examples --no-curl-examples --no-unit-tests --no-opencl --no-benchmarks
-make && sudo make install
+./configure && make && sudo make install
 ```
 
 ### Code Base
 
-Since Bro does not come with broker enabled in the latest release, we have to build it from source.
+Build Bro with the new Broker version:
 
 ```
-git clone --recursive https://github.com/bro/bro
+git clone --recursive https://github.com/bro/bro -b topic/actor-system
 cd bro
-```
-
-Optionally, when using the new Broker version, use the latest development version of bro and broker.
-
-```
-git checkout topic/actor-system
-git submodule update --init
-```
-
-Now, build Bro. Please read [Bro Dependencies](https://www.bro.org/sphinx/install/install.html#required-dependencies) and how to install them.
-Leave out the flag --enable-broker for the development version of bro and broker.
-
-```
-./configure --enable-broker
-make && sudo make install
+./configure && make && sudo make install
 ```
 
 ### Bro Scripts
 
-The Bro scripts have to be extended to talk to osquery hosts.
-
-For the stable broker version (0.6), please find the scripts in the [bro-osquery](https://github.com/bro/bro-osquery) repository.
-For the latest broker version, please find the scripts in the [bro-osquery fork by iBigQ](https://github.com/iBigQ/bro-osquery) repository under the branch [`bro-osquery-actor`](https://github.com/iBigQ/bro-osquery/tree/bro-osquery-actor).
+The Bro scripts have to be extended to talk to osquery hosts. Please
+find the scripts in the [bro-osquery fork by
+iBigQ](https://github.com/iBigQ/bro-osquery) repository under the
+branch
+[`bro-osquery-actor`](https://github.com/iBigQ/bro-osquery/tree/bro-osquery-actor).


### PR DESCRIPTION
Updating README to match the changes in https://github.com/iBigQ/osquery/pull/1, plus simplyging to leave out the old-Broker version.

